### PR TITLE
filterstreamにリツイートを含めるか除外するかを設定で変更可能にする

### DIFF
--- a/twitter_settings.rb
+++ b/twitter_settings.rb
@@ -17,6 +17,7 @@ UserConfig[:favorite_queue_delay] ||= 100
 UserConfig[:follow_queue_delay] ||= 100
 UserConfig[:direct_message_queue_delay] ||= 100
 UserConfig[:filter_realtime_rewind] ||= true
+UserConfig[:filter_dont_exclude_retweet] ||= false
 UserConfig[:anti_retrieve_fail] ||= false
 
 Plugin.create(:twitter_settings) do
@@ -62,6 +63,8 @@ Plugin.create(:twitter_settings) do
     settings _('リアルタイム更新') do
       boolean(_('リスト(Streaming API)'), :filter_realtime_rewind).
         tooltip _('Twitter の Streaming APIを用いて、リアルタイムにリストの更新等を受け取ります')
+      boolean(_('StreamingにRTを含める'), :filter_dont_exclude_retweet).
+        tooltip _('サードパーティープラグインでRTをStreaming受信したい場合に有効にします。副作用として既存プラグインに意図しないRTが表示される場合があります ')
     end
 
     settings(_('その他')) do


### PR DESCRIPTION
https://github.com/mikutter/streaming/pull/3 の streaming 変更の設定に対するUI設定です。
tooltipの説明は従来の「RTを除外」がデフォルト前提で、必要に応じてRTを含める説明にしています。